### PR TITLE
forwarding additional Git client's repo data to dog house

### DIFF
--- a/src/scan.rs
+++ b/src/scan.rs
@@ -229,10 +229,18 @@ pub fn upload_scan(config: &Config, paths: Vec<String>, scanner: String, input: 
     } else {
         project = current_dir.file_name().expect("Failed to get directory name").to_str().expect("Failed to convert OsStr to str").to_string();
     }
+    let repo_data = std::env::var("REPO_DATA").unwrap_or_else(|_| "".to_string()); //encoded data to forward.
 
-    let scan_upload_url = format!(
-        "{}/api/cli/scan-upload?token={}&engine={}&run_id={}&project={}&ci={}&ci_platform={}", base_url, token, scanner, run_id, project, in_ci, ci_platform
-    );
+    let scan_upload_url = if repo_data.is_empty() {
+        format!(
+            "{}/api/cli/scan-upload?token={}&engine={}&run_id={}&project={}&ci={}&ci_platform={}", base_url, token, scanner, run_id, project, in_ci, ci_platform
+        )
+    } else {
+        format!(
+            "{}/api/cli/scan-upload?token={}&engine={}&run_id={}&project={}&ci={}&ci_platform={}&repo_data={}", base_url, token, scanner, run_id, project, in_ci, ci_platform, repo_data
+        )
+    };
+
     let git_config_upload_url = format!(
         "{}/api/cli/git-config-upload?token={}&run_id={}", base_url, token, run_id
     );


### PR DESCRIPTION
Some additional info is needed on dog house so that sast_scan is created with more repo info
It'd be consumed in 

https://github.com/Corgea/doghouse/compare/more_github_fixes#diff-7fb412808754eb12ee1b172c34c44eb9ce58b3bba43d62ffcb986ad7917588a8R92
It may be better if sast_scan object was created earlier with 'pending' status or something that is not visible to user so that we don't have to pass things around.

tested: 
- github upload flow
- regular upload flow
