### PR TITLE
Scan types

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,13 @@ enum Commands {
 
         #[arg(short, long, help = "Fail on (exits with error code 1) based on blocking rules defined in the web app.")]
         fail: bool,
+
+        #[arg(
+            short,
+            long,
+            help = "Specify the scan type. By default, a full scan is run, which includes all scan types. You can choose to run a partial scan by specifying one or more of the following types: base AI blast (base), malicious code detection (malicious), policy checks (policy), secret detection (secrets), and PII scan (pii). Use comma-separated values to run multiple types, e.g., 'policy,secrets,pii'."
+        )]
+        scan_type: Option<String>,
     },
     /// Wait for the latest in progress scan
     Wait {
@@ -99,7 +106,10 @@ enum Commands {
         id: String,
     },
     /// Setup a git hook, currently only pre-commit is supported
-    SetupHooks,
+    SetupHooks {
+        #[arg(long, short, help = "Include default config (scan types are pii, secrets and fail on levels are CR, HI, ME, LO).")]
+        default_config: bool,
+    },
 }
 
 #[derive(Subcommand, Debug, Clone, PartialEq)]
@@ -170,7 +180,7 @@ fn main() {
                 }
             }
         }
-        Some(Commands::Scan { scanner , fail_on, fail, only_uncommitted }) => {
+        Some(Commands::Scan { scanner , fail_on, fail, only_uncommitted, scan_type }) => {
             verify_token_and_exit_when_fail(&corgea_config);
             if let Some(level) = fail_on {
                 if *scanner != Scanner::Blast {
@@ -197,11 +207,26 @@ fn main() {
                 eprintln!("fail and fail_on cannot be used together.");
                 std::process::exit(1);
             }
-            
+
+            if let Some(scan_type) = scan_type {
+                if scan_type.is_empty() {
+                    eprintln!("scan_type cannot be empty.");
+                    std::process::exit(1);
+                }
+                let supported_scan_types = ["base", "malicious", "policy", "secrets", "pii"];
+                let scan_types: Vec<_> = scan_type.split(',').map(|t| t.trim()).collect();
+                for scan in scan_types {
+                    if !supported_scan_types.contains(&scan) {
+                        eprintln!("Invalid scan_type: {}. Supported types are: base, malicious, policy, secrets, pii.", scan);
+                        std::process::exit(1);
+                    }
+                }
+            }
+
             match scanner {
                 Scanner::Snyk => scan::run_snyk(&corgea_config),
                 Scanner::Semgrep => scan::run_semgrep(&corgea_config),
-                Scanner::Blast => scanners::blast::run(&corgea_config, fail_on.clone(), fail, only_uncommitted)
+                Scanner::Blast => scanners::blast::run(&corgea_config, fail_on.clone(), fail, only_uncommitted, scan_type.clone())
             }
         }
         Some(Commands::Wait { scan_id }) => {
@@ -220,8 +245,8 @@ fn main() {
             verify_token_and_exit_when_fail(&corgea_config);
             inspect::run(&corgea_config, issue, json, summary, fix, diff, id)
         }
-        Some(Commands::SetupHooks) => {
-            setup_hooks::setup_pre_commit_hook();
+        Some(Commands::SetupHooks { default_config }) => {
+            setup_hooks::setup_pre_commit_hook(*default_config);
         }
         None => {
             utils::terminal::show_welcome_message();

--- a/src/scanners/blast.rs
+++ b/src/scanners/blast.rs
@@ -10,7 +10,13 @@ use uuid::Uuid;
 
 
 
-pub fn run(config: &Config, fail_on: Option<String>, fail: &bool, only_uncommitted: &bool) {
+pub fn run(
+    config: &Config, 
+    fail_on: Option<String>, 
+    fail: &bool, 
+    only_uncommitted: &bool,
+    scan_type: Option<String>,
+) {
     println!(
         "\nScanning with BLAST 🚀🚀🚀"
     );
@@ -84,7 +90,7 @@ pub fn run(config: &Config, fail_on: Option<String>, fail: &bool, only_uncommitt
         }
     }
     println!("\n\nSubmitting scan to Corgea:");
-    let scan_id = match utils::api::upload_zip(&zip_path, &config.get_token(), &config.get_url(), &project_name, repo_info) {
+    let scan_id = match utils::api::upload_zip(&zip_path, &config.get_token(), &config.get_url(), &project_name, repo_info, scan_type) {
         Ok(result) => result,
         Err(e) => {
             eprintln!("\n\nOh no! We encountered an issue while uploading the zip file '{}' to the server.\nPlease ensure that:

--- a/src/scanners/blast.rs
+++ b/src/scanners/blast.rs
@@ -16,6 +16,7 @@ pub fn run(
     fail: &bool, 
     only_uncommitted: &bool,
     scan_type: Option<String>,
+    policy: Option<String>,
 ) {
     println!(
         "\nScanning with BLAST 🚀🚀🚀\n\n"
@@ -108,7 +109,7 @@ pub fn run(
     let _ = packaging_thread.join();
     print!("\r{}Project packaged successfully.\n", utils::terminal::set_text_color("", utils::terminal::TerminalColor::Green));
     println!("\n\nSubmitting scan to Corgea:");
-    let scan_id = match utils::api::upload_zip(&zip_path, &config.get_token(), &config.get_url(), &project_name, repo_info, scan_type) {
+    let scan_id = match utils::api::upload_zip(&zip_path, &config.get_token(), &config.get_url(), &project_name, repo_info, scan_type, policy) {
         Ok(result) => result,
         Err(e) => {
             eprintln!("\n\nOh no! We encountered an issue while uploading the zip file '{}' to the server.\nPlease ensure that:

--- a/src/setup_hooks.rs
+++ b/src/setup_hooks.rs
@@ -64,7 +64,7 @@ pub fn setup_pre_commit_hook(include_default_scan_types: bool) {
     // Create pre-commit hook content
     let hook_content = format!(r#"#!/bin/sh
 # Corgea pre-commit hook
-corgea scan blast --only-uncommitted --fail-on 'CR,HI,ME,LO' --scan-type {}
+corgea scan blast --only-uncommitted --fail-on LO --scan-type {}
 "#, scan_types.join(","));
 
     // Write pre-commit hook

--- a/src/setup_hooks.rs
+++ b/src/setup_hooks.rs
@@ -1,0 +1,60 @@
+use crate::utils::terminal;
+
+pub fn setup_pre_commit_hook() {
+    println!("Setting up pre-commit hook...");
+
+    // Check if we're in a git repo
+    let git_dir = match std::fs::metadata(".git") {
+        Ok(metadata) => {
+            if metadata.is_dir() {
+                ".git"
+            } else {
+                eprintln!("Error: .git exists but is not a directory");
+                std::process::exit(1);
+            }
+        }
+        Err(_) => {
+            eprintln!("Error: Not a git repository (or any of the parent directories)");
+            std::process::exit(1);
+        }
+    };
+
+    let hooks_dir = format!("{}/hooks", git_dir);
+    let pre_commit_path = format!("{}/pre-commit", hooks_dir);
+
+    // Create hooks directory if it doesn't exist
+    std::fs::create_dir_all(&hooks_dir).unwrap_or_else(|e| {
+        eprintln!("Failed to create hooks directory: {}", e);
+        std::process::exit(1);
+    });
+
+    // Check if pre-commit hook already exists
+    if std::path::Path::new(&pre_commit_path).exists() {
+        if !terminal::ask_yes_no("Pre-commit hook already exists. Do you want to overwrite it?", false) {
+            println!("Skipping pre-commit hook setup.");
+            return;
+        }
+    }
+
+    // Create pre-commit hook content
+    let hook_content = r#"#!/bin/sh
+# Corgea pre-commit hook
+corgea scan --only-uncommitted
+"#;
+
+    // Write pre-commit hook
+    std::fs::write(&pre_commit_path, hook_content).unwrap_or_else(|e| {
+        eprintln!("Failed to write pre-commit hook: {}", e);
+        std::process::exit(1);
+    });
+
+    // Make hook executable
+    #[cfg(unix)]
+    std::fs::set_permissions(&pre_commit_path, std::os::unix::fs::PermissionsExt::from_mode(0o755))
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to set pre-commit hook permissions: {}", e);
+            std::process::exit(1);
+        });
+
+    println!("Successfully installed pre-commit hook!");
+}

--- a/src/utils/api.rs
+++ b/src/utils/api.rs
@@ -126,7 +126,7 @@ pub fn upload_zip(
             }
         }
         if let Some(scan_type) = scan_type.clone() {
-            form = form.part("scan_type", multipart::Part::text(scan_type.to_string()));
+            form = form.part("scan_configs", multipart::Part::text(scan_type.to_string()));
         }
         if let Some(policy) = policy.clone() {
             form = form.part("target_policies", multipart::Part::text(policy.to_string()));

--- a/src/utils/api.rs
+++ b/src/utils/api.rs
@@ -31,7 +31,14 @@ fn check_for_warnings(headers: &HeaderMap, status: StatusCode) {
     }
 }
 
-pub fn upload_zip(file_path: &str , token: &str, url: &str, project_name: &str, repo_info: Option<utils::generic::RepoInfo>) -> Result<String, Box<dyn std::error::Error>> {
+pub fn upload_zip(
+    file_path: &str , 
+    token: &str, 
+    url: &str, 
+    project_name: &str, 
+    repo_info: Option<utils::generic::RepoInfo>,
+    scan_type: Option<String>
+) -> Result<String, Box<dyn std::error::Error>> {
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(5 * 60))
         .build()
@@ -117,7 +124,9 @@ pub fn upload_zip(file_path: &str , token: &str, url: &str, project_name: &str, 
                 form = form.part("sha", multipart::Part::text(sha.to_string()));
             }
         }
-
+        if let Some(scan_type) = scan_type.clone() {
+            form = form.part("scan_type", multipart::Part::text(scan_type.to_string()));
+        }
 
         let response = match client
         .patch(format!("{}{}/start-scan/{}/", url, API_BASE, transfer_id))

--- a/src/utils/terminal.rs
+++ b/src/utils/terminal.rs
@@ -173,7 +173,25 @@ pub fn prompt_to_continue_or_exit(message: Option<&str>) {
     std::io::stdin().read_line(&mut input).unwrap();
 }
 
-
+pub fn ask_yes_no(question: &str, should_default: bool) -> bool {
+    loop {
+        print!("{} (y/n): ", question);
+        io::stdout().flush().unwrap();
+        
+        let mut input = String::new();
+        io::stdin().read_line(&mut input).unwrap();
+        
+        match input.trim().to_lowercase().as_str() {
+            "y" | "yes" => return true,
+            "n" | "no" => return false,
+            _ => if should_default {
+                return true;
+            } else {
+                println!("Please answer with yes/y or no/n");
+            }
+        }
+    }
+}
 
 pub fn print_table(table: Vec<Vec<String>>, page:  Option<u32>, total_pages: Option<u32>) {
     let columns = table.iter().enumerate().fold(vec![vec![]; table[0].len()], |mut acc, (_i, row)| {


### PR DESCRIPTION
The change includes:
- Create a command to install a pre commit hook that will corgea scan
- Updated the scan command to have a new param 'scan-type' which will give the user the ability to run a specific type of scans only like secrets scans or pii scans, Fusion & Doghouse PRs will follow