### PR TITLE
Showing API ZIP Validation

### DIFF
--- a/src/scanners/blast.rs
+++ b/src/scanners/blast.rs
@@ -78,7 +78,7 @@ pub fn run(
                     *stop_signal.lock().unwrap() = true;
                     print!("\r{}", utils::terminal::set_text_color("", utils::terminal::TerminalColor::Reset));
                     eprintln!(
-                        "\n\nOops! It seems there are no uncommitted changes to scan in your project.\nPlease ensure you have made changes that need to be scanned.\n\n", 
+                        "\n\nOops! It seems there are no scannable uncommitted changes in your project.\nYou may have uncommitted changes, but none match the types of files we can scan.\n\n"
                     );
                     std::process::exit(1);
                 }

--- a/src/utils/generic.rs
+++ b/src/utils/generic.rs
@@ -7,6 +7,29 @@ use std::fs::{self, File};
 use std::env;
 use git2::Repository;
 
+// Global exclude globs used across multiple functions
+const DEFAULT_EXCLUDE_GLOBS: &[&str] = &[
+    "**/tests/**",
+    "**/.corgea/**",
+    "**/test/**",
+    "**/spec/**",
+    "**/specs/**",
+    "**/node_modules/**",
+    "**/tmp/**",
+    "**/migrations/**",
+    "**/python*/site-packages/**",
+    "**/*.mmdb",
+    "**/*.css",
+    "**/*.less",
+    "**/*.scss",
+    "**/*.map",
+    "**/*.env",
+    "**/*.sh",
+    "**/.vs/**",
+    "**/.vscode/**",
+    "**/.idea/**",
+];
+
 pub fn create_zip_from_filtered_files<P: AsRef<Path>>(
     directory: P,
     exclude_globs: Option<&[&str]>,
@@ -38,24 +61,7 @@ pub fn create_zip_from_list_of_files<P: AsRef<Path>>(
     output_zip: P,
     exclude_globs: Option<&[&str]>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let exclude_globs = exclude_globs.unwrap_or(&[
-        "**/tests/**",
-        "**/.corgea/**",
-        "**/test/**",
-        "**/spec/**",
-        "**/specs/**",
-        "**/node_modules/**",
-        "**/tmp/**",
-        "**/migrations/**",
-        "**/python*/site-packages/**",
-        "**/*.mmdb",
-        "**/*.css",
-        "**/*.less",
-        "**/*.scss",
-        "**/*.map",
-        "**/*.env",
-        "**/*.sh",
-    ]);
+    let exclude_globs = exclude_globs.unwrap_or(DEFAULT_EXCLUDE_GLOBS);
 
     let mut glob_builder = GlobSetBuilder::new();
     for &pattern in exclude_globs {
@@ -97,13 +103,8 @@ pub fn get_untracked_and_modified_files(repo_path: &str) -> Result<Vec<String>, 
 
     let statuses = repo.statuses(None)?;
     
-    let globs_to_ignore = [
-        "**/.vs/**",
-        "**/.vscode/**",
-        "**/.idea/**",
-    ];
     let mut glob_builder = GlobSetBuilder::new();
-    for &pattern in &globs_to_ignore {
+    for &pattern in DEFAULT_EXCLUDE_GLOBS {
         glob_builder.add(Glob::new(pattern).unwrap());
     }
     let glob_set = glob_builder.build().unwrap();


### PR DESCRIPTION
- Fixed a bug where running scan --only-uncommitted with uncommitted changes that are all non-scannable files (e.g., CSS, scripts, or tests) resulted in creating an empty ZIP file instead of showing a message.
- Started to show 400 API errors in the error message 

<img width="813" height="140" alt="image" src="https://github.com/user-attachments/assets/1cfb7572-5213-4eaf-80c7-ff1273d2389c" />
<img width="1113" height="354" alt="image" src="https://github.com/user-attachments/assets/40cba5ab-f5c2-4372-808d-c31775bf134a" />
